### PR TITLE
fix: remove unused jobqueue multiprocessor config field

### DIFF
--- a/jobqueue/jobqueue.go
+++ b/jobqueue/jobqueue.go
@@ -32,7 +32,6 @@ type (
 	config struct {
 		jobTimeout      time.Duration
 		shutdownTimeout time.Duration
-		multiprocessor  bool
 		errorHandler    func(error)
 		buffer          int
 		concurrency     int


### PR DESCRIPTION
## Why?
Makes CI static check happy.