### PR TITLE
refactor(capabilities): remove need to list common capabilities

### DIFF
--- a/capabilities/assert/assert.go
+++ b/capabilities/assert/assert.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 
-	ipldprime "github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	ipldschema "github.com/ipld/go-ipld-prime/schema"
 	"github.com/storacha/go-libstoracha/capabilities/types"
@@ -23,7 +22,7 @@ var assertSchema []byte
 var assertTS = mustLoadTS()
 
 func mustLoadTS() *ipldschema.TypeSystem {
-	ts, err := ipldprime.LoadSchemaBytes(assertSchema)
+	ts, err := types.LoadSchemaBytes(assertSchema)
 	if err != nil {
 		panic(fmt.Errorf("loading assert schema: %w", err))
 	}

--- a/capabilities/assert/assert.ipldsch
+++ b/capabilities/assert/assert.ipldsch
@@ -1,8 +1,3 @@
-type DID bytes
-type HasMultihash any
-type URL string
-type V1Link link
-
 type Range struct {
 	offset Int
 	length optional Int

--- a/capabilities/blob/blob.ipldsch
+++ b/capabilities/blob/blob.ipldsch
@@ -1,7 +1,3 @@
-type DID bytes
-type Multihash bytes
-type URL string
-
 type Blob struct {
   digest Multihash
   size Int
@@ -13,8 +9,6 @@ type AllocateCaveats struct {
   cause Link
 }
 
-type HTTPHeaders any
-
 type Address struct {
   URL URL (rename "url")
   headers HTTPHeaders
@@ -24,15 +18,6 @@ type Address struct {
 type AllocateOk struct {
   size Int
   address optional Address
-}
-
-type Await struct {
-  selector String
-  link Link
-} representation tuple
-
-type Promise struct {
-  ucanAwait Await (rename "ucan/await")
 }
 
 type AcceptCaveats struct {

--- a/capabilities/blob/schema.go
+++ b/capabilities/blob/schema.go
@@ -5,8 +5,8 @@ import (
 	_ "embed"
 	"fmt"
 
-	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/storacha/go-libstoracha/capabilities/types"
 )
 
 //go:embed blob.ipldsch
@@ -15,7 +15,7 @@ var blobSchema []byte
 var blobTS = mustLoadTS()
 
 func mustLoadTS() *schema.TypeSystem {
-	ts, err := ipld.LoadSchemaBytes(blobSchema)
+	ts, err := types.LoadSchemaBytes(blobSchema)
 	if err != nil {
 		panic(fmt.Errorf("loading blob schema: %w", err))
 	}

--- a/capabilities/claim/claim.go
+++ b/capabilities/claim/claim.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 
-	ipldprime "github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	ipldschema "github.com/ipld/go-ipld-prime/schema"
 	"github.com/multiformats/go-multiaddr"
@@ -21,7 +20,7 @@ var claimSchema []byte
 var claimTypeSystem = mustLoadTS()
 
 func mustLoadTS() *ipldschema.TypeSystem {
-	ts, err := ipldprime.LoadSchemaBytes(claimSchema)
+	ts, err := types.LoadSchemaBytes(claimSchema)
 	if err != nil {
 		panic(fmt.Errorf("loading claim schema: %w", err))
 	}

--- a/capabilities/claim/claim.ipldsch
+++ b/capabilities/claim/claim.ipldsch
@@ -1,4 +1,3 @@
-type Multiaddr bytes
 type CacheCaveats struct {
 	claim Link
   provider Provider

--- a/capabilities/pdp/pdp.go
+++ b/capabilities/pdp/pdp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/go-data-segment/merkletree"
-	ipldprime "github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	ipldschema "github.com/ipld/go-ipld-prime/schema"
 	"github.com/storacha/go-libstoracha/capabilities/types"
@@ -24,7 +23,7 @@ var pdpSchema []byte
 var pdpTS = mustLoadTS()
 
 func mustLoadTS() *ipldschema.TypeSystem {
-	ts, err := ipldprime.LoadSchemaBytes(pdpSchema)
+	ts, err := types.LoadSchemaBytes(pdpSchema)
 	if err != nil {
 		panic(fmt.Errorf("loading blob schema: %w", err))
 	}

--- a/capabilities/pdp/pdp.ipldsch
+++ b/capabilities/pdp/pdp.ipldsch
@@ -1,12 +1,9 @@
-type Node bytes
-type PieceLink link
-
 type AcceptCaveats struct {
 	piece   PieceLink
 }
 
 type ProofData struct {
-	path  [Node]
+	path  [MerkleNode]
 	index Int
 }
 

--- a/capabilities/space/blob/blob.ipldsch
+++ b/capabilities/space/blob/blob.ipldsch
@@ -1,5 +1,3 @@
-type Multihash bytes
-
 type Blob struct {
     digest Multihash
     size Int
@@ -12,15 +10,6 @@ type AddCaveats struct {
 type AddOk struct {
     site Promise
 }
-
-type Promise struct {
-  ucanAwait Await (rename "ucan/await")
-}
-
-type Await struct {
-  selector String
-  link Link
-} representation tuple
 
 type RemoveCaveats struct {
     digest Multihash
@@ -47,8 +36,6 @@ type ListBlobItem struct {
     blob Blob
     insertedAt ISO8601Date
 }
-
-type ISO8601Date string
 
 type GetCaveats struct {
     digest Multihash

--- a/capabilities/space/blob/schema.go
+++ b/capabilities/space/blob/schema.go
@@ -5,8 +5,8 @@ import (
 	_ "embed"
 	"fmt"
 
-	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/storacha/go-libstoracha/capabilities/types"
 )
 
 //go:embed blob.ipldsch
@@ -15,7 +15,7 @@ var blobSchema []byte
 var blobTS = mustLoadTS()
 
 func mustLoadTS() *schema.TypeSystem {
-	ts, err := ipld.LoadSchemaBytes(blobSchema)
+	ts, err := types.LoadSchemaBytes(blobSchema)
 	if err != nil {
 		panic(fmt.Errorf("loading space/blob schema: %w", err))
 	}

--- a/capabilities/types/converters.go
+++ b/capabilities/types/converters.go
@@ -100,7 +100,7 @@ var PieceLinkConverter = options.NamedLinkConverter("PieceLink", func(c cid.Cid)
 	return p.Link().(cidlink.Link).Cid, nil
 })
 
-var MerkleNodeConverter = options.NamedBytesConverter("Node", func(b []byte) (merkletree.Node, error) {
+var MerkleNodeConverter = options.NamedBytesConverter("MerkleNode", func(b []byte) (merkletree.Node, error) {
 	if len(b) != len(merkletree.Node{}) {
 		return merkletree.Node{}, ErrWrongLength
 	}

--- a/capabilities/types/types.go
+++ b/capabilities/types/types.go
@@ -92,4 +92,13 @@ func FromHash(mh mh.Multihash) HasMultihash {
 	return digest(mh)
 }
 
+type Await struct {
+	Selector string
+	Link     ipld.Link
+}
+
+type Promise struct {
+	UcanAwait Await
+}
+
 var linkOrDigest = schema.Or(schema.Mapped(schema.Link(), Link), schema.Mapped(schema.Struct[DigestModel](DigestType(), nil), Digest))

--- a/capabilities/types/types.ipldsch
+++ b/capabilities/types/types.ipldsch
@@ -2,3 +2,23 @@ type Headers {String:String}
 type Digest struct {
   digest Bytes
 }
+
+type Await struct {
+  selector String
+  link Link
+} representation tuple
+
+type Promise struct {
+  ucanAwait Await (rename "ucan/await")
+}
+
+type Multihash bytes
+type Multiaddr bytes
+type HasMultihash any
+type DID bytes
+type URL string
+type HTTPHeaders any
+type V1Link link
+type PieceLink link
+type MerkleNode bytes
+type ISO8601Date string

--- a/capabilities/types/util.go
+++ b/capabilities/types/util.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/ipld/go-ipld-prime/schema"
+	schemadmt "github.com/ipld/go-ipld-prime/schema/dmt"
+	schemadsl "github.com/ipld/go-ipld-prime/schema/dsl"
+)
+
+// LoadSchemaBytes is a shortcut for LoadSchema for the common case where
+// the schema is available as a buffer or a string, such as via go:embed.
+func LoadSchemaBytes(src []byte) (*schema.TypeSystem, error) {
+	return LoadSchema("", bytes.NewReader(src))
+}
+
+// LoadSchemaBytes is a shortcut for LoadSchema for the common case where
+// the schema is a file on disk.
+func LoadSchemaFile(path string) (*schema.TypeSystem, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return LoadSchema(path, f)
+}
+
+// LoadSchema parses an IPLD Schema in its DSL form
+// and compiles its types into a standalone TypeSystem.
+func LoadSchema(name string, r io.Reader) (*schema.TypeSystem, error) {
+	sch, err := schemadsl.Parse(name, r)
+	if err != nil {
+		return nil, err
+	}
+	ts := new(schema.TypeSystem)
+	ts.Init()
+	schema.SpawnDefaultBasicTypes(ts)
+	baseSch, err := schemadsl.Parse("", bytes.NewReader(typesSchema))
+	if err != nil {
+		return nil, err
+	}
+	err = schemadmt.SpawnSchemaTypes(ts, baseSch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the schema types
+	err = schemadmt.SpawnSchemaTypes(ts, sch)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: if this fails and the user forgot to check Compile's returned error,
+	// we can leave the TypeSystem in an unfortunate broken state:
+	// they can obtain types out of the TypeSystem and they are non-nil,
+	// but trying to use them in any way may result in panics.
+	// Consider making that less prone to misuse, such as making it illegal to
+	// call TypeByName until ValidateGraph is happy.
+	if errs := ts.ValidateGraph(); errs != nil {
+		// Return the first error.
+		for _, err := range errs {
+			return nil, err
+		}
+	}
+
+	return ts, nil
+}


### PR DESCRIPTION
# Goals

Remove the annoying need to list the common types used in each schema. Also adds a Promise common type.