### PR TITLE
feat: add ucan/conclude capability

### DIFF
--- a/capabilities/types/converters.go
+++ b/capabilities/types/converters.go
@@ -117,6 +117,14 @@ var ISO8601DateConverter = options.NamedStringConverter("ISO8601Date",
 		return t.Format(time.RFC3339), nil
 	})
 
+var UnixTimeMilliConverter = options.NamedIntConverter("UnixTimeMilli",
+	func(millis int64) (time.Time, error) {
+		return time.UnixMilli(millis), nil
+	},
+	func(t time.Time) (int64, error) {
+		return t.UnixMilli(), nil
+	})
+
 var Converters = []bindnode.Option{
 	MultiaddrConverter,
 	HasMultihashConverter,
@@ -127,4 +135,5 @@ var Converters = []bindnode.Option{
 	PieceLinkConverter,
 	MerkleNodeConverter,
 	ISO8601DateConverter,
+	UnixTimeMilliConverter,
 }

--- a/capabilities/types/types.ipldsch
+++ b/capabilities/types/types.ipldsch
@@ -22,3 +22,4 @@ type V1Link link
 type PieceLink link
 type MerkleNode bytes
 type ISO8601Date string
+type UnixTimeMilli int

--- a/capabilities/ucan/conclude.go
+++ b/capabilities/ucan/conclude.go
@@ -1,0 +1,84 @@
+package ucan
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/result/failure"
+	"github.com/storacha/go-ucanto/core/schema"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/storacha/go-ucanto/validator"
+)
+
+const ConcludeAbility = "ucan/conclude"
+
+// ConcludeCaveats represents the caveats required to perform a ucan/conclude invocation.
+type ConcludeCaveats struct {
+	// Receipt is the CID of the content with the receipt.
+	Receipt ipld.Link
+}
+
+func (cc ConcludeCaveats) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&cc, ConcludeCaveatsType(), types.Converters...)
+}
+
+var ConcludeCaveatsReader = schema.Struct[ConcludeCaveats](ConcludeCaveatsType(), nil, types.Converters...)
+
+// ConcludeOk represents the successful response for a ucan/conclude invocation.
+type ConcludeOk struct {
+	// Time is the timestamp when ucan/conclude invocation was completed.
+	Time time.Time
+}
+
+func (co ConcludeOk) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&co, ConcludeOkType(), types.Converters...)
+}
+
+var ConcludeOkReader = schema.Struct[ConcludeOk](ConcludeOkType(), nil, types.Converters...)
+
+// Conclude is a capability that represents a receipt using a special UCAN capability.
+var Conclude = validator.NewCapability(
+	ConcludeAbility,
+	schema.DIDString(),
+	ConcludeCaveatsReader,
+	func(claimed, delegated ucan.Capability[ConcludeCaveats]) failure.Failure {
+		// Check if the with field matches
+		if fail := equalWith(claimed, delegated); fail != nil {
+			return fail
+		}
+
+		// Check if the receipt matches
+		if fail := equalReceipt(claimed, delegated); fail != nil {
+			return fail
+		}
+
+		return nil
+	},
+)
+
+// equalWith validates that the claimed capability's `with` field matches the delegated one.
+func equalWith(claimed, delegated ucan.Capability[ConcludeCaveats]) failure.Failure {
+	if claimed.With() != delegated.With() {
+		return schema.NewSchemaError(fmt.Sprintf(
+			"Resource '%s' doesn't match delegated '%s'",
+			claimed.With(), delegated.With(),
+		))
+	}
+
+	return nil
+}
+
+// equalReceipt checks if the receipt matches between two capabilities.
+func equalReceipt(claimed, delegated ucan.Capability[ConcludeCaveats]) failure.Failure {
+	if delegated.Nb().Receipt != claimed.Nb().Receipt {
+		return schema.NewSchemaError(fmt.Sprintf(
+			"claimed receipt '%s' doesn't match delegated '%s'",
+			claimed.Nb().Receipt, delegated.Nb().Receipt,
+		))
+	}
+
+	return nil
+}

--- a/capabilities/ucan/conclude_test.go
+++ b/capabilities/ucan/conclude_test.go
@@ -1,0 +1,36 @@
+package ucan_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/storacha/go-libstoracha/capabilities/internal/testutil"
+	"github.com/storacha/go-libstoracha/capabilities/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripConcludeCaveats(t *testing.T) {
+	nb := ucan.ConcludeCaveats{
+		Receipt: testutil.RandomCID(t),
+	}
+
+	node, err := nb.ToIPLD()
+	require.NoError(t, err)
+
+	rnb, err := ucan.ConcludeCaveatsReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, nb, rnb)
+}
+
+func TestRoundTripConcludeOk(t *testing.T) {
+	ok := ucan.ConcludeOk{
+		Time: time.Now().Truncate(time.Millisecond),
+	}
+
+	node, err := ok.ToIPLD()
+	require.NoError(t, err)
+
+	rok, err := ucan.ConcludeOkReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, ok, rok)
+}

--- a/capabilities/ucan/schema.go
+++ b/capabilities/ucan/schema.go
@@ -1,0 +1,31 @@
+package ucan
+
+import (
+	// for schema embed
+	_ "embed"
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+)
+
+//go:embed ucan.ipldsch
+var ucanSchema []byte
+
+var ucanTS = mustLoadTS()
+
+func mustLoadTS() *schema.TypeSystem {
+	ts, err := types.LoadSchemaBytes(ucanSchema)
+	if err != nil {
+		panic(fmt.Errorf("loading ucan schema: %w", err))
+	}
+	return ts
+}
+
+func ConcludeCaveatsType() schema.Type {
+	return ucanTS.TypeByName("ConcludeCaveats")
+}
+
+func ConcludeOkType() schema.Type {
+	return ucanTS.TypeByName("ConcludeOk")
+}

--- a/capabilities/ucan/ucan.ipldsch
+++ b/capabilities/ucan/ucan.ipldsch
@@ -1,0 +1,7 @@
+type ConcludeCaveats struct {
+    receipt Link
+}
+
+type ConcludeOk struct {
+    time UnixTimeMilli
+}


### PR DESCRIPTION
ref. #4 

This PR adds types, schemas and readers for the `ucan/conclude` capability.

The timestamp in `ConcludeOk` is assumed to be in milliseconds since the epoch because the `ucanConcludeProvider` in `upload-api` uses `Date.now()`, which gives unix time in milliseconds (https://github.com/storacha/upload-service/blob/a96d7e8950f8b948f1a94e28ef73b33dad9d8822/packages/upload-api/src/ucan/conclude.js#L31)