### PR TITLE
feat: add web3.storage/blob legacy capabilities

### DIFF
--- a/capabilities/web3.storage/blob/accept.go
+++ b/capabilities/web3.storage/blob/accept.go
@@ -1,0 +1,61 @@
+package blob
+
+import (
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/result/failure"
+	"github.com/storacha/go-ucanto/core/schema"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/storacha/go-ucanto/validator"
+)
+
+const AcceptAbility = "web3.storage/blob/accept"
+
+type AcceptCaveats struct {
+	Space did.DID
+	Blob  Blob
+	TTL   int
+	Put   types.Promise
+}
+
+func (ac AcceptCaveats) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&ac, AcceptCaveatsType(), types.Converters...)
+}
+
+var AcceptCaveatsReader = schema.Struct[AcceptCaveats](AcceptCaveatsType(), nil, types.Converters...)
+
+type AcceptOk struct {
+	Site ucan.Link
+}
+
+func (ao AcceptOk) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&ao, AcceptOkType(), types.Converters...)
+}
+
+var AcceptOkReader = schema.Struct[AcceptOk](AcceptOkType(), nil, types.Converters...)
+
+var Accept = validator.NewCapability(
+	AcceptAbility,
+	schema.DIDString(),
+	AcceptCaveatsReader,
+	func(claimed, delegated ucan.Capability[AcceptCaveats]) failure.Failure {
+		fail := equalWith(claimed.With(), delegated.With())
+		if fail != nil {
+			return fail
+		}
+
+		fail = equalBlob(claimed.Nb().Blob, delegated.Nb().Blob)
+		if fail != nil {
+			return fail
+		}
+
+		fail = equalTTL(claimed.Nb().TTL, delegated.Nb().TTL)
+		if fail != nil {
+			return fail
+		}
+
+		return checkSpace(claimed.Nb().Space.String(), delegated.Nb().Space.String())
+	},
+)

--- a/capabilities/web3.storage/blob/accept.go
+++ b/capabilities/web3.storage/blob/accept.go
@@ -15,7 +15,7 @@ const AcceptAbility = "web3.storage/blob/accept"
 
 type AcceptCaveats struct {
 	Space did.DID
-	Blob  Blob
+	Blob  types.Blob
 	TTL   int
 	Put   types.Promise
 }

--- a/capabilities/web3.storage/blob/accept_test.go
+++ b/capabilities/web3.storage/blob/accept_test.go
@@ -13,7 +13,7 @@ func TestRoundTripAcceptCaveats(t *testing.T) {
 	digest, bytes := testutil.RandomBytes(t, 256)
 	nb := blob.AcceptCaveats{
 		Space: testutil.RandomPrincipal(t).DID(),
-		Blob: blob.Blob{
+		Blob: types.Blob{
 			Digest: digest,
 			Size:   uint64(len(bytes)),
 		},

--- a/capabilities/web3.storage/blob/accept_test.go
+++ b/capabilities/web3.storage/blob/accept_test.go
@@ -1,0 +1,48 @@
+package blob_test
+
+import (
+	"testing"
+
+	"github.com/storacha/go-libstoracha/capabilities/internal/testutil"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-libstoracha/capabilities/web3.storage/blob"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripAcceptCaveats(t *testing.T) {
+	digest, bytes := testutil.RandomBytes(t, 256)
+	nb := blob.AcceptCaveats{
+		Space: testutil.RandomPrincipal(t).DID(),
+		Blob: blob.Blob{
+			Digest: digest,
+			Size:   uint64(len(bytes)),
+		},
+		TTL: 3600,
+		Put: types.Promise{
+			UcanAwait: types.Await{
+				Selector: ".out.ok",
+				Link:     testutil.RandomCID(t),
+			},
+		},
+	}
+
+	node, err := nb.ToIPLD()
+	require.NoError(t, err)
+
+	rnb, err := blob.AcceptCaveatsReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, nb, rnb)
+}
+
+func TestRoundTripAcceptOk(t *testing.T) {
+	ok := blob.AcceptOk{
+		Site: testutil.RandomCID(t),
+	}
+
+	node, err := ok.ToIPLD()
+	require.NoError(t, err)
+
+	rok, err := blob.AcceptOkReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, ok, rok)
+}

--- a/capabilities/web3.storage/blob/allocate.go
+++ b/capabilities/web3.storage/blob/allocate.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ipld/go-ipld-prime/datamodel"
-	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/result/failure"
@@ -18,14 +17,9 @@ import (
 
 const AllocateAbility = "web3.storage/blob/allocate"
 
-type Blob struct {
-	Digest multihash.Multihash
-	Size   uint64
-}
-
 type AllocateCaveats struct {
 	Space did.DID
-	Blob  Blob
+	Blob  types.Blob
 	Cause ucan.Link
 }
 

--- a/capabilities/web3.storage/blob/allocate.go
+++ b/capabilities/web3.storage/blob/allocate.go
@@ -1,0 +1,77 @@
+package blob
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/result/failure"
+	"github.com/storacha/go-ucanto/core/schema"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/storacha/go-ucanto/validator"
+)
+
+const AllocateAbility = "web3.storage/blob/allocate"
+
+type Blob struct {
+	Digest multihash.Multihash
+	Size   uint64
+}
+
+type AllocateCaveats struct {
+	Space did.DID
+	Blob  Blob
+	Cause ucan.Link
+}
+
+func (ac AllocateCaveats) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&ac, AllocateCaveatsType(), types.Converters...)
+}
+
+var AllocateCaveatsReader = schema.Struct[AllocateCaveats](AllocateCaveatsType(), nil, types.Converters...)
+
+type Address struct {
+	URL       url.URL
+	Headers   http.Header
+	ExpiresAt time.Time
+}
+
+type AllocateOk struct {
+	Size    uint64
+	Address *Address
+}
+
+func (ao AllocateOk) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&ao, AllocateOkType(), types.Converters...)
+}
+
+var AllocateOkReader = schema.Struct[AllocateOk](AllocateOkType(), nil, types.Converters...)
+
+var Allocate = validator.NewCapability(
+	AllocateAbility,
+	schema.DIDString(),
+	AllocateCaveatsReader,
+	func(claimed, delegated ucan.Capability[AllocateCaveats]) failure.Failure {
+		fail := equalWith(claimed.With(), delegated.With())
+		if fail != nil {
+			return fail
+		}
+
+		fail = equalBlob(claimed.Nb().Blob, delegated.Nb().Blob)
+		if fail != nil {
+			return fail
+		}
+
+		fail = checkLink(claimed.Nb().Cause, delegated.Nb().Cause)
+		if fail != nil {
+			return fail
+		}
+
+		return checkSpace(claimed.Nb().Space.String(), delegated.Nb().Space.String())
+	},
+)

--- a/capabilities/web3.storage/blob/allocate_test.go
+++ b/capabilities/web3.storage/blob/allocate_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/storacha/go-libstoracha/capabilities/internal/testutil"
+	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-libstoracha/capabilities/web3.storage/blob"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ func TestRoundTripAllocateCaveats(t *testing.T) {
 	digest, bytes := testutil.RandomBytes(t, 256)
 	nb := blob.AllocateCaveats{
 		Space: testutil.RandomPrincipal(t).DID(),
-		Blob: blob.Blob{
+		Blob: types.Blob{
 			Digest: digest,
 			Size:   uint64(len(bytes)),
 		},

--- a/capabilities/web3.storage/blob/allocate_test.go
+++ b/capabilities/web3.storage/blob/allocate_test.go
@@ -1,0 +1,52 @@
+package blob_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/storacha/go-libstoracha/capabilities/internal/testutil"
+	"github.com/storacha/go-libstoracha/capabilities/web3.storage/blob"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripAllocateCaveats(t *testing.T) {
+	digest, bytes := testutil.RandomBytes(t, 256)
+	nb := blob.AllocateCaveats{
+		Space: testutil.RandomPrincipal(t).DID(),
+		Blob: blob.Blob{
+			Digest: digest,
+			Size:   uint64(len(bytes)),
+		},
+		Cause: testutil.RandomCID(t),
+	}
+
+	node, err := nb.ToIPLD()
+	require.NoError(t, err)
+
+	rnb, err := blob.AllocateCaveatsReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, nb, rnb)
+}
+
+func TestRoundTripAllocateOk(t *testing.T) {
+	testURL, err := url.Parse("http://storacha.network")
+	require.NoError(t, err)
+
+	ok := blob.AllocateOk{
+		Size: 1024,
+		Address: &blob.Address{
+			URL:       *testURL,
+			Headers:   http.Header{"Testhdr": []string{"test"}},
+			ExpiresAt: time.Now().UTC().Truncate(time.Second),
+		},
+	}
+
+	node, err := ok.ToIPLD()
+	require.NoError(t, err)
+
+	rok, err := blob.AllocateOkReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, ok, rok)
+}

--- a/capabilities/web3.storage/blob/blob.ipldsch
+++ b/capabilities/web3.storage/blob/blob.ipldsch
@@ -1,0 +1,32 @@
+type Blob struct {
+  digest Multihash
+  size Int
+}
+
+type AllocateCaveats struct {
+  space DID
+  blob Blob
+  cause Link
+}
+
+type Address struct {
+  URL URL (rename "url")
+  headers HTTPHeaders
+  expiresAt ISO8601Date
+}
+
+type AllocateOk struct {
+  size Int
+  address optional Address
+}
+
+type AcceptCaveats struct {
+  space DID
+  blob Blob
+  TTL Int (rename "ttl")
+  put Promise (rename "_put")
+}
+
+type AcceptOk struct {
+  site Link
+}

--- a/capabilities/web3.storage/blob/blob.ipldsch
+++ b/capabilities/web3.storage/blob/blob.ipldsch
@@ -1,8 +1,3 @@
-type Blob struct {
-  digest Multihash
-  size Int
-}
-
 type AllocateCaveats struct {
   space DID
   blob Blob

--- a/capabilities/web3.storage/blob/derives.go
+++ b/capabilities/web3.storage/blob/derives.go
@@ -1,0 +1,72 @@
+package blob
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/multiformats/go-multibase"
+	"github.com/storacha/go-ucanto/core/result/failure"
+	"github.com/storacha/go-ucanto/core/schema"
+	"github.com/storacha/go-ucanto/ucan"
+)
+
+func equalWith(claimed, delegated ucan.Resource) failure.Failure {
+	if claimed != delegated {
+		return schema.NewSchemaError(fmt.Sprintf("Resource '%s' doesn't match delegated '%s'", claimed, delegated))
+	}
+
+	return nil
+}
+
+func equalBlob(claimed, delegated Blob) failure.Failure {
+	// Check if the blob digest matches
+	if !bytes.Equal(delegated.Digest, claimed.Digest) {
+		claimedDigest, _ := multibase.Encode(multibase.Base58BTC, claimed.Digest)
+		delegatedDigest, _ := multibase.Encode(multibase.Base58BTC, delegated.Digest)
+
+		return schema.NewSchemaError(fmt.Sprintf(
+			"Link %s violates imposed %s constraint",
+			claimedDigest, delegatedDigest,
+		))
+	}
+
+	// Check size constraint
+	if claimed.Size > 0 && delegated.Size > 0 {
+		if claimed.Size > delegated.Size {
+			return schema.NewSchemaError(fmt.Sprintf(
+				"Size constraint violation: %d > %d",
+				claimed.Size, delegated.Size,
+			))
+		}
+	}
+
+	return nil
+}
+
+func checkLink(claimed, delegated ucan.Link) failure.Failure {
+	return checkConstraint(claimed.String(), delegated.String(), "link")
+}
+
+func checkSpace(claimed, delegated ucan.Resource) failure.Failure {
+	return checkConstraint(claimed, delegated, "space")
+}
+
+func checkConstraint(claimed, delegated string, constraint string) failure.Failure {
+	if delegated == "" || delegated == "*" {
+		return nil
+	}
+
+	if claimed != delegated {
+		return schema.NewSchemaError(fmt.Sprintf("%s '%s' doesn't match delegated '%s'", constraint, claimed, delegated))
+	}
+
+	return nil
+}
+
+func equalTTL(claimed, delegated int) failure.Failure {
+	if claimed != delegated {
+		return schema.NewSchemaError(fmt.Sprintf("TTL '%d' doesn't match delegated '%d'", claimed, delegated))
+	}
+
+	return nil
+}

--- a/capabilities/web3.storage/blob/derives.go
+++ b/capabilities/web3.storage/blob/derives.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/multiformats/go-multibase"
+	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -18,7 +19,7 @@ func equalWith(claimed, delegated ucan.Resource) failure.Failure {
 	return nil
 }
 
-func equalBlob(claimed, delegated Blob) failure.Failure {
+func equalBlob(claimed, delegated types.Blob) failure.Failure {
 	// Check if the blob digest matches
 	if !bytes.Equal(delegated.Digest, claimed.Digest) {
 		claimedDigest, _ := multibase.Encode(multibase.Base58BTC, claimed.Digest)

--- a/capabilities/web3.storage/blob/schema.go
+++ b/capabilities/web3.storage/blob/schema.go
@@ -1,0 +1,39 @@
+package blob
+
+import (
+	// for schema embed
+	_ "embed"
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+)
+
+//go:embed blob.ipldsch
+var blobSchema []byte
+
+var blobTS = mustLoadTS()
+
+func mustLoadTS() *schema.TypeSystem {
+	ts, err := types.LoadSchemaBytes(blobSchema)
+	if err != nil {
+		panic(fmt.Errorf("loading blob schema: %w", err))
+	}
+	return ts
+}
+
+func AllocateCaveatsType() schema.Type {
+	return blobTS.TypeByName("AllocateCaveats")
+}
+
+func AllocateOkType() schema.Type {
+	return blobTS.TypeByName("AllocateOk")
+}
+
+func AcceptCaveatsType() schema.Type {
+	return blobTS.TypeByName("AcceptCaveats")
+}
+
+func AcceptOkType() schema.Type {
+	return blobTS.TypeByName("AcceptOk")
+}


### PR DESCRIPTION
ref #4 

Add schemas, types and readers for the `web3.storage/blob` family of legacy capabilities.