### PR TITLE
feat: add S3-backed datastore implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A unified Go library (monorepo) for Storacha functionality. This repository host
 ## Subpackages
 - [capabilities](./capabilities)
     - **Description:** UCAN capability definitions for the Storacha ecosystem.
+- [datastore](./datastore)
+    - **Description:** Implementations of the [Datastore](https://github.com/ipfs/go-datastore) interface on top of different data backends.
 - [metadata](./metadata)
     - **Description:** IPNI metadata used by the Storacha Network.
 - [jobqueue](./jobqueue)

--- a/datastore/s3/s3.go
+++ b/datastore/s3/s3.go
@@ -1,0 +1,410 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/endpointcreds"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+const (
+	// listMax is the largest amount of objects you can request from S3 in a list
+	// call.
+	listMax = 1000
+
+	// deleteMax is the largest amount of objects you can delete from S3 in a
+	// delete objects call.
+	deleteMax = 1000
+
+	defaultWorkers = 100
+
+	// credsRefreshWindow, subtracted from the endpointcred's expiration time, is the
+	// earliest time the endpoint creds can be refreshed.
+	credsRefreshWindow = 2 * time.Minute
+)
+
+var _ ds.Datastore = (*S3Bucket)(nil)
+
+type S3Bucket struct {
+	Config
+	S3 *s3.S3
+}
+
+type Config struct {
+	AccessKey           string
+	SecretKey           string
+	SessionToken        string
+	Bucket              string
+	Region              string
+	RegionEndpoint      string
+	ForcePathStyle      bool
+	RootDirectory       string
+	Workers             int
+	CredentialsEndpoint string
+}
+
+func NewS3Datastore(conf Config) (*S3Bucket, error) {
+	if conf.Workers == 0 {
+		conf.Workers = defaultWorkers
+	}
+
+	awsConfig := aws.NewConfig()
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new session: %s", err)
+	}
+
+	d := defaults.Get()
+	creds := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.StaticProvider{Value: credentials.Value{
+			AccessKeyID:     conf.AccessKey,
+			SecretAccessKey: conf.SecretKey,
+			SessionToken:    conf.SessionToken,
+		}},
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{},
+		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(sess)},
+		endpointcreds.NewProviderClient(*d.Config, d.Handlers, conf.CredentialsEndpoint,
+			func(p *endpointcreds.Provider) { p.ExpiryWindow = credsRefreshWindow },
+		),
+		defaults.RemoteCredProvider(*d.Config, d.Handlers),
+	})
+
+	if conf.RegionEndpoint != "" {
+		awsConfig.WithEndpoint(conf.RegionEndpoint)
+	}
+
+	if conf.ForcePathStyle {
+		awsConfig.WithS3ForcePathStyle(true)
+	}
+
+	awsConfig.WithCredentials(creds)
+	awsConfig.CredentialsChainVerboseErrors = aws.Bool(true)
+	awsConfig.WithRegion(conf.Region)
+
+	sess, err = session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new session with aws config: %s", err)
+	}
+	s3obj := s3.New(sess)
+
+	return &S3Bucket{
+		S3:     s3obj,
+		Config: conf,
+	}, nil
+}
+
+func (s *S3Bucket) Put(ctx context.Context, k ds.Key, value []byte) error {
+	_, err := s.S3.PutObjectWithContext(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(s.s3Path(k.String())),
+		Body:   bytes.NewReader(value),
+	})
+	return err
+}
+
+func (s *S3Bucket) Sync(ctx context.Context, prefix ds.Key) error {
+	return nil
+}
+
+func (s *S3Bucket) Get(ctx context.Context, k ds.Key) ([]byte, error) {
+	resp, err := s.S3.GetObjectWithContext(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(s.s3Path(k.String())),
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ds.ErrNotFound
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return io.ReadAll(resp.Body)
+}
+
+func (s *S3Bucket) Has(ctx context.Context, k ds.Key) (exists bool, err error) {
+	_, err = s.GetSize(ctx, k)
+	if err != nil {
+		if err == ds.ErrNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *S3Bucket) GetSize(ctx context.Context, k ds.Key) (size int, err error) {
+	resp, err := s.S3.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(s.s3Path(k.String())),
+	})
+	if err != nil {
+		if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == "NotFound" {
+			return -1, ds.ErrNotFound
+		}
+		return -1, err
+	}
+	return int(*resp.ContentLength), nil
+}
+
+func (s *S3Bucket) Delete(ctx context.Context, k ds.Key) error {
+	_, err := s.S3.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(s.s3Path(k.String())),
+	})
+	if isNotFound(err) {
+		// delete is idempotent
+		err = nil
+	}
+	return err
+}
+
+func (s *S3Bucket) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
+	if q.Orders != nil || q.Filters != nil {
+		return nil, fmt.Errorf("s3ds: filters or orders are not supported")
+	}
+
+	// S3 store a "/foo" key as "foo" so we need to trim the leading "/"
+	q.Prefix = strings.TrimPrefix(q.Prefix, "/")
+
+	limit := q.Limit + q.Offset
+	if limit == 0 || limit > listMax {
+		limit = listMax
+	}
+
+	resp, err := s.S3.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(s.Bucket),
+		Prefix:  aws.String(s.s3Path(q.Prefix) + "/"),
+		MaxKeys: aws.Int64(int64(limit)),
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return dsq.ResultsFromIterator(q, dsq.Iterator{
+				Close: func() error {
+					return nil
+				},
+				Next: func() (dsq.Result, bool) {
+					return dsq.Result{}, false
+				},
+			}), nil
+		}
+		return nil, err
+	}
+
+	index := q.Offset
+	nextValue := func() (dsq.Result, bool) {
+		for index >= len(resp.Contents) {
+			if !*resp.IsTruncated {
+				return dsq.Result{}, false
+			}
+
+			index -= len(resp.Contents)
+
+			resp, err = s.S3.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
+				Bucket:            aws.String(s.Bucket),
+				Prefix:            aws.String(s.s3Path(q.Prefix)),
+				Delimiter:         aws.String("/"),
+				MaxKeys:           aws.Int64(listMax),
+				ContinuationToken: resp.NextContinuationToken,
+			})
+			if err != nil {
+				return dsq.Result{Error: err}, false
+			}
+		}
+
+		entry := dsq.Entry{
+			Key:  ds.NewKey(*resp.Contents[index].Key).String(),
+			Size: int(*resp.Contents[index].Size),
+		}
+		if !q.KeysOnly {
+			value, err := s.Get(ctx, ds.NewKey(entry.Key))
+			if err != nil {
+				return dsq.Result{Error: err}, false
+			}
+			entry.Value = value
+		}
+
+		index++
+		return dsq.Result{Entry: entry}, true
+	}
+
+	return dsq.ResultsFromIterator(q, dsq.Iterator{
+		Close: func() error {
+			return nil
+		},
+		Next: nextValue,
+	}), nil
+}
+
+func (s *S3Bucket) Batch(_ context.Context) (ds.Batch, error) {
+	return &s3Batch{
+		s:          s,
+		ops:        make(map[string]batchOp),
+		numWorkers: s.Workers,
+	}, nil
+}
+
+func (s *S3Bucket) Close() error {
+	return nil
+}
+
+func (s *S3Bucket) s3Path(p string) string {
+	return path.Join(s.RootDirectory, p)
+}
+
+func isNotFound(err error) bool {
+	s3Err, ok := err.(awserr.Error)
+	return ok && s3Err.Code() == s3.ErrCodeNoSuchKey
+}
+
+type s3Batch struct {
+	s          *S3Bucket
+	ops        map[string]batchOp
+	numWorkers int
+}
+
+type batchOp struct {
+	val    []byte
+	delete bool
+}
+
+func (b *s3Batch) Put(ctx context.Context, k ds.Key, val []byte) error {
+	b.ops[k.String()] = batchOp{
+		val:    val,
+		delete: false,
+	}
+	return nil
+}
+
+func (b *s3Batch) Delete(ctx context.Context, k ds.Key) error {
+	b.ops[k.String()] = batchOp{
+		val:    nil,
+		delete: true,
+	}
+	return nil
+}
+
+func (b *s3Batch) Commit(ctx context.Context) error {
+	var (
+		deleteObjs []*s3.ObjectIdentifier
+		putKeys    []ds.Key
+	)
+	for k, op := range b.ops {
+		if op.delete {
+			deleteObjs = append(deleteObjs, &s3.ObjectIdentifier{
+				Key: aws.String(k),
+			})
+		} else {
+			putKeys = append(putKeys, ds.NewKey(k))
+		}
+	}
+
+	numJobs := len(putKeys) + (len(deleteObjs) / deleteMax)
+	jobs := make(chan func() error, numJobs)
+	results := make(chan error, numJobs)
+
+	numWorkers := b.numWorkers
+	if numJobs < numWorkers {
+		numWorkers = numJobs
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+	defer wg.Wait()
+
+	for w := 0; w < numWorkers; w++ {
+		go func() {
+			defer wg.Done()
+			worker(jobs, results)
+		}()
+	}
+
+	for _, k := range putKeys {
+		jobs <- b.newPutJob(ctx, k, b.ops[k.String()].val)
+	}
+
+	if len(deleteObjs) > 0 {
+		for i := 0; i < len(deleteObjs); i += deleteMax {
+			limit := deleteMax
+			if len(deleteObjs[i:]) < limit {
+				limit = len(deleteObjs[i:])
+			}
+
+			jobs <- b.newDeleteJob(ctx, deleteObjs[i:i+limit])
+		}
+	}
+	close(jobs)
+
+	var errs []string
+	for i := 0; i < numJobs; i++ {
+		err := <-results
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("s3ds: failed batch operation:\n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
+}
+
+func (b *s3Batch) newPutJob(ctx context.Context, k ds.Key, value []byte) func() error {
+	return func() error {
+		return b.s.Put(ctx, k, value)
+	}
+}
+
+func (b *s3Batch) newDeleteJob(ctx context.Context, objs []*s3.ObjectIdentifier) func() error {
+	return func() error {
+		resp, err := b.s.S3.DeleteObjectsWithContext(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(b.s.Bucket),
+			Delete: &s3.Delete{
+				Objects: objs,
+			},
+		})
+		if err != nil && !isNotFound(err) {
+			return err
+		}
+
+		var errs []string
+		for _, err := range resp.Errors {
+			if err.Code != nil && *err.Code == s3.ErrCodeNoSuchKey {
+				// idempotent
+				continue
+			}
+			errs = append(errs, err.String())
+		}
+
+		if len(errs) > 0 {
+			return fmt.Errorf("failed to delete objects: %s", errs)
+		}
+
+		return nil
+	}
+}
+
+func worker(jobs <-chan func() error, results chan<- error) {
+	for j := range jobs {
+		results <- j()
+	}
+}
+
+var _ ds.Batching = (*S3Bucket)(nil)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.2
 toolchain go1.23.3
 
 require (
+	github.com/aws/aws-sdk-go v1.55.7
 	github.com/filecoin-project/go-data-segment v0.0.1
 	github.com/filecoin-project/go-fil-commcid v0.2.0
 	github.com/ipfs/go-cid v0.5.0
@@ -51,6 +52,7 @@ require (
 	github.com/ipld/go-car v0.6.2 // indirect
 	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-pubsub v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
+github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -299,6 +301,10 @@ github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABo
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=


### PR DESCRIPTION
Moving to go-libstoracha the S3 datastore implementation used by the storage node (https://github.com/storacha/storage/tree/main/pkg/s3).

I copied it as is. The only change is that I added `defaults.RemoteCredProvider(*d.Config, d.Handlers)` to the list of credential providers. The RemoteCredProvider is the one able to resolve credentials when they are IAM role-based.

Tests are lacking for now, I created an issue to address that when we have some time: #24.