### PR TITLE
feat:added receipts and receipt readers for all capabilties

### DIFF
--- a/capabilities/blob/accept.go
+++ b/capabilities/blob/accept.go
@@ -3,6 +3,8 @@ package blob
 import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/ucan"
@@ -39,6 +41,13 @@ type AcceptOk struct {
 
 func (ao AcceptOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AcceptOkType(), types.Converters...)
+}
+
+type AcceptReceipt receipt.Receipt[AcceptOk, failure.Failure]
+type AcceptReceiptReader receipt.ReceiptReader[AcceptOk, failure.Failure]
+
+func NewAcceptReceiptReader() (AcceptReceiptReader, error) {
+	return receipt.NewReceiptReader[AcceptOk, failure.Failure](blobSchema)
 }
 
 var AcceptCaveatsReader = schema.Struct[AcceptCaveats](AcceptCaveatsType(), nil, types.Converters...)

--- a/capabilities/blob/allocate.go
+++ b/capabilities/blob/allocate.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/ucan"
@@ -39,6 +41,13 @@ type AllocateOk struct {
 
 func (ao AllocateOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AllocateOkType(), types.Converters...)
+}
+
+type AllocateReceipt receipt.Receipt[AllocateOk, failure.Failure]
+type AllocateReceiptReader receipt.ReceiptReader[AllocateOk, failure.Failure]
+
+func NewAllocateReceiptReader() (AllocateReceiptReader, error) {
+	return receipt.NewReceiptReader[AllocateOk, failure.Failure](blobSchema)
 }
 
 var AllocateCaveatsReader = schema.Struct[AllocateCaveats](AllocateCaveatsType(), nil, types.Converters...)

--- a/capabilities/blob/replica/allocate.go
+++ b/capabilities/blob/replica/allocate.go
@@ -3,6 +3,8 @@ package replica
 import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/ucan"
@@ -47,6 +49,13 @@ func (ac AllocateCaveats) ToIPLD() (datamodel.Node, error) {
 }
 
 var AllocateCaveatsReader = schema.Struct[AllocateCaveats](AllocateCaveatsType(), nil, types.Converters...)
+
+type AllocateReceipt receipt.Receipt[AllocateOk, failure.Failure]
+type AllocateReceiptReader receipt.ReceiptReader[AllocateOk, failure.Failure]
+
+func NewAllocateReceiptReader() (AllocateReceiptReader, error) {
+	return receipt.NewReceiptReader[AllocateOk, failure.Failure](replicaSchema)
+}
 
 // Allocate is a capability that allows an agent to allocate a Blob for replication
 // into a space identified by did:key in the `with` field.

--- a/capabilities/blob/replica/transfer.go
+++ b/capabilities/blob/replica/transfer.go
@@ -5,6 +5,8 @@ import (
 	"github.com/storacha/go-ucanto/did"
 
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/go-ucanto/validator"
@@ -43,6 +45,13 @@ func (t TransferOk) ToIPLD() (datamodel.Node, error) {
 
 func (tc TransferCaveats) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&tc, TransferCaveatsType(), types.Converters...)
+}
+
+type TransferReceipt receipt.Receipt[TransferOk, failure.Failure]
+type TransferReceiptReader receipt.ReceiptReader[TransferOk, failure.Failure]
+
+func NewTransferReceiptReader() (TransferReceiptReader, error) {
+	return receipt.NewReceiptReader[TransferOk, failure.Failure](replicaSchema)
 }
 
 var TransferCaveatsReader = schema.Struct[TransferCaveats](TransferCaveatsType(), nil, types.Converters...)

--- a/capabilities/http/put.go
+++ b/capabilities/http/put.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -45,6 +46,13 @@ type PutOk struct {
 
 func (po PutOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&po, PutOkType(), types.Converters...)
+}
+
+type PutReceipt receipt.Receipt[PutOk, failure.Failure]
+type PutReceiptReader receipt.ReceiptReader[PutOk, failure.Failure]
+
+func NewPutReceiptReader() (PutReceiptReader, error) {
+	return receipt.NewReceiptReader[PutOk, failure.Failure](httpSchema)
 }
 
 var PutOkReader = schema.Struct[PutOk](PutOkType(), nil, types.Converters...)

--- a/capabilities/pdp/accept.go
+++ b/capabilities/pdp/accept.go
@@ -6,6 +6,8 @@ import (
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-libstoracha/piece/piece"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/validator"
 )
@@ -37,4 +39,11 @@ type AcceptOk struct {
 
 func (ao AcceptOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AcceptOkType(), types.Converters...)
+}
+
+type AcceptReceipt receipt.Receipt[AcceptOk, failure.Failure]
+type AcceptReceiptReader receipt.ReceiptReader[AcceptOk, failure.Failure]
+
+func NewAcceptReceiptReader() (AcceptReceiptReader, error) {
+	return receipt.NewReceiptReader[AcceptOk, failure.Failure](pdpSchema)
 }

--- a/capabilities/pdp/info.go
+++ b/capabilities/pdp/info.go
@@ -6,6 +6,8 @@ import (
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-libstoracha/piece/piece"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/validator"
 )
@@ -32,6 +34,13 @@ type InfoOk struct {
 
 func (io InfoOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&io, InfoOkType(), types.Converters...)
+}
+
+type InfoReceipt receipt.Receipt[InfoOk, failure.Failure]
+type InfoReceiptReader receipt.ReceiptReader[InfoOk, failure.Failure]
+
+func NewInfoReceiptReader() (InfoReceiptReader, error) {
+	return receipt.NewReceiptReader[InfoOk, failure.Failure](pdpSchema)
 }
 
 var InfoCaveatsReader = schema.Struct[InfoCaveats](InfoCaveatsType(), nil, types.Converters...)

--- a/capabilities/space/blob/add.go
+++ b/capabilities/space/blob/add.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/multiformats/go-multibase"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -37,6 +38,14 @@ type AddOk struct {
 
 func (ao AddOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AddOkType(), types.Converters...)
+}
+
+type AddReceipt receipt.Receipt[AddOk, failure.Failure]
+
+type AddReceiptReader receipt.ReceiptReader[AddOk, failure.Failure]
+
+func NewAddReceiptReader() (AddReceiptReader, error) {
+	return receipt.NewReceiptReader[AddOk, failure.Failure](blobSchema)
 }
 
 var AddOkReader = schema.Struct[AddOk](AddOkType(), nil, types.Converters...)

--- a/capabilities/space/blob/get.go
+++ b/capabilities/space/blob/get.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -45,6 +46,13 @@ type GetOk struct {
 
 func (ok GetOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ok, GetOkType(), types.Converters...)
+}
+
+type GetReceipt receipt.Receipt[GetOk, failure.Failure]
+type GetReceiptReader receipt.ReceiptReader[GetOk, failure.Failure]
+
+func NewGetReceiptReader() (GetReceiptReader, error) {
+	return receipt.NewReceiptReader[GetOk, failure.Failure](blobSchema)
 }
 
 var GetOkReader = schema.Struct[GetOk](GetOkType(), nil, types.Converters...)

--- a/capabilities/space/blob/list.go
+++ b/capabilities/space/blob/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -47,6 +48,13 @@ type ListBlobItem struct {
 
 func (lo ListOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&lo, ListOkType(), types.Converters...)
+}
+
+type ListReceipt receipt.Receipt[ListOk, failure.Failure]
+type ListReceiptReader receipt.ReceiptReader[ListOk, failure.Failure]
+
+func NewListReceiptReader() (ListReceiptReader, error) {
+	return receipt.NewReceiptReader[ListOk, failure.Failure](blobSchema)
 }
 
 var ListOkReader = schema.Struct[ListOk](ListOkType(), nil, types.Converters...)

--- a/capabilities/space/blob/remove.go
+++ b/capabilities/space/blob/remove.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -37,6 +38,14 @@ type RemoveOk struct {
 
 func (ro RemoveOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ro, RemoveOkType(), types.Converters...)
+}
+
+type RemoveReceipt receipt.Receipt[RemoveOk, failure.Failure]
+
+type RemoveReceiptReader receipt.ReceiptReader[RemoveOk, failure.Failure]
+
+func NewRemoveReceiptReader() (RemoveReceiptReader, error) {
+	return receipt.NewReceiptReader[RemoveOk, failure.Failure](blobSchema)
 }
 
 var RemoveOkReader = schema.Struct[RemoveOk](RemoveOkType(), nil, types.Converters...)

--- a/capabilities/space/blob/replicate.go
+++ b/capabilities/space/blob/replicate.go
@@ -3,6 +3,8 @@ package blob
 import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/validator"
 
@@ -40,6 +42,13 @@ type ReplicateOk struct {
 
 func (ro ReplicateOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ro, ReplicateOkType(), types.Converters...)
+}
+
+type ReplicateReceipt receipt.Receipt[ReplicateOk, failure.Failure]
+type ReplicateReceiptReader receipt.ReceiptReader[ReplicateOk, failure.Failure]
+
+func NewReplicateReceiptReader() (ReplicateReceiptReader, error) {
+	return receipt.NewReceiptReader[ReplicateOk, failure.Failure](blobSchema)
 }
 
 var ReplicateOkReader = schema.Struct[ReplicateOk](ReplicateOkType(), nil, types.Converters...)

--- a/capabilities/space/index/add.go
+++ b/capabilities/space/index/add.go
@@ -11,6 +11,8 @@ import (
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/go-ucanto/validator"
+
+	"github.com/storacha/go-ucanto/core/receipt"
 )
 
 const AddAbility = "space/index/add"
@@ -32,6 +34,14 @@ type AddOk struct {
 
 func (ao AddOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AddOkType(), types.Converters...)
+}
+
+type AddReceipt receipt.Receipt[AddOk, failure.Failure]
+
+type AddReceiptReader receipt.ReceiptReader[AddOk, failure.Failure]
+
+func NewAddReceiptReader() (AddReceiptReader, error) {
+	return receipt.NewReceiptReader[AddOk, failure.Failure](indexSchema)
 }
 
 var AddOkReader = schema.Struct[AddOk](AddOkType(), nil, types.Converters...)

--- a/capabilities/upload/add.go
+++ b/capabilities/upload/add.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -31,6 +32,13 @@ type AddOk struct {
 
 func (ao AddOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AddOkType(), types.Converters...)
+}
+
+type AddReceipt receipt.Receipt[AddOk, failure.Failure]
+type AddReceiptReader receipt.ReceiptReader[AddOk, failure.Failure]
+
+func NewAddReceiptReader() (AddReceiptReader, error) {
+	return receipt.NewReceiptReader[AddOk, failure.Failure](uploadSchema)
 }
 
 var AddOkReader = schema.Struct[AddOk](AddOkType(), nil, types.Converters...)

--- a/capabilities/upload/get.go
+++ b/capabilities/upload/get.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -34,6 +35,13 @@ type GetOk struct {
 
 func (ok GetOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ok, GetOkType(), types.Converters...)
+}
+
+type GetReceipt receipt.Receipt[GetOk, failure.Failure]
+type GetReceiptReader receipt.ReceiptReader[GetOk, failure.Failure]
+
+func NewGetReceiptReader() (GetReceiptReader, error) {
+	return receipt.NewReceiptReader[GetOk, failure.Failure](uploadSchema)
 }
 
 var GetOkReader = schema.Struct[GetOk](GetOkType(), nil, types.Converters...)

--- a/capabilities/upload/list.go
+++ b/capabilities/upload/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -45,6 +46,13 @@ type ListOk struct {
 
 func (lo ListOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&lo, ListOkType(), types.Converters...)
+}
+
+type ListReceipt receipt.Receipt[ListOk, failure.Failure]
+type ListReceiptReader receipt.ReceiptReader[ListOk, failure.Failure]
+
+func NewListReceiptReader() (ListReceiptReader, error) {
+	return receipt.NewReceiptReader[ListOk, failure.Failure](uploadSchema)
 }
 
 var ListOkReader = schema.Struct[ListOk](ListOkType(), nil, types.Converters...)

--- a/capabilities/upload/remove.go
+++ b/capabilities/upload/remove.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/ucan"
@@ -33,6 +34,13 @@ func (ro RemoveOk) ToIPLD() (datamodel.Node, error) {
 }
 
 var RemoveOkReader = schema.Struct[RemoveOk](RemoveOkType(), nil, types.Converters...)
+
+type RemoveReceipt receipt.Receipt[RemoveOk, failure.Failure]
+type RemoveReceiptReader receipt.ReceiptReader[RemoveOk, failure.Failure]
+
+func NewRemoveReceiptReader() (RemoveReceiptReader, error) {
+	return receipt.NewReceiptReader[RemoveOk, failure.Failure](uploadSchema)
+}
 
 var Remove = validator.NewCapability(
 	RemoveAbility,

--- a/capabilities/web3.storage/blob/accept.go
+++ b/capabilities/web3.storage/blob/accept.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/did"
@@ -32,6 +33,13 @@ type AcceptOk struct {
 
 func (ao AcceptOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AcceptOkType(), types.Converters...)
+}
+
+type AcceptReceipt receipt.Receipt[AcceptOk, failure.Failure]
+type AcceptReceiptReader receipt.ReceiptReader[AcceptOk, failure.Failure]
+
+func NewAcceptReceiptReader() (AcceptReceiptReader, error) {
+	return receipt.NewReceiptReader[AcceptOk, failure.Failure](blobSchema)
 }
 
 var AcceptOkReader = schema.Struct[AcceptOk](AcceptOkType(), nil, types.Converters...)

--- a/capabilities/web3.storage/blob/allocate.go
+++ b/capabilities/web3.storage/blob/allocate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
 	"github.com/storacha/go-ucanto/did"
@@ -42,6 +43,13 @@ type AllocateOk struct {
 
 func (ao AllocateOk) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ao, AllocateOkType(), types.Converters...)
+}
+
+type AllocateReceipt receipt.Receipt[AllocateOk, failure.Failure]
+type AllocateReceiptReader receipt.ReceiptReader[AllocateOk, failure.Failure]
+
+func NewAllocateReceiptReader() (AllocateReceiptReader, error) {
+	return receipt.NewReceiptReader[AllocateOk, failure.Failure](blobSchema)
 }
 
 var AllocateOkReader = schema.Struct[AllocateOk](AllocateOkType(), nil, types.Converters...)


### PR DESCRIPTION
Implements ready-to-use receipt readers for all capability types to eliminate the need for clients to handle receipt parsing manually. [issue-20](https://github.com/storacha/go-libstoracha/issues/20)