### PR TITLE
feat: implement upload/* wildcard capability derivation

### DIFF
--- a/capabilities/upload/add.go
+++ b/capabilities/upload/add.go
@@ -48,6 +48,11 @@ var Add = validator.NewCapability(
 			return fail
 		}
 
+		// Allow derivation from upload/* wildcard capability
+		if delegated.Can() == UploadAbility {
+			return nil
+		}
+
 		if fail := equalRoot(claimed.Nb().Root, delegated.Nb().Root); fail != nil {
 			return fail
 		}

--- a/capabilities/upload/derives.go
+++ b/capabilities/upload/derives.go
@@ -45,3 +45,199 @@ func equalShards(claimed, delegated []ipld.Link) failure.Failure {
 
 	return nil
 }
+
+// AddDerive implements the derivation logic for upload/add capabilities
+func AddDerive(claimed, delegated any) failure.Failure {
+	// Convert to generic capabilities to access basic properties
+	claimedCap, ok := claimed.(interface {
+		Can() string
+		With() string
+		Nb() AddCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid claimed capability type")
+	}
+
+	delegatedCap, ok := delegated.(interface {
+		Can() string
+		With() string
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid delegated capability type")
+	}
+
+	if err := validateSpaceDID(claimedCap.With()); err != nil {
+		return err
+	}
+
+	if claimedCap.With() != delegatedCap.With() {
+		return schema.NewSchemaError(fmt.Sprintf(
+			"Resource '%s' doesn't match delegated '%s'",
+			claimedCap.With(), delegatedCap.With(),
+		))
+	}
+
+	// Allow derivation from upload/* wildcard capability
+	if delegatedCap.Can() == UploadAbility {
+		return nil
+	}
+
+	// If not wildcard, need to validate specific constraints
+	delegatedAddCap, ok := delegated.(interface {
+		Nb() AddCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("delegated capability doesn't have AddCaveats")
+	}
+
+	if fail := equalRoot(claimedCap.Nb().Root, delegatedAddCap.Nb().Root); fail != nil {
+		return fail
+	}
+
+	if len(delegatedAddCap.Nb().Shards) > 0 {
+		if fail := equalShards(claimedCap.Nb().Shards, delegatedAddCap.Nb().Shards); fail != nil {
+			return fail
+		}
+	}
+	return nil
+}
+
+// GetDerive implements the derivation logic for upload/get capabilities
+func GetDerive(claimed, delegated any) failure.Failure {
+	// Convert to generic capabilities to access basic properties
+	claimedCap, ok := claimed.(interface {
+		Can() string
+		With() string
+		Nb() GetCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid claimed capability type")
+	}
+
+	delegatedCap, ok := delegated.(interface {
+		Can() string
+		With() string
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid delegated capability type")
+	}
+
+	if err := validateSpaceDID(claimedCap.With()); err != nil {
+		return err
+	}
+
+	if claimedCap.With() != delegatedCap.With() {
+		return schema.NewSchemaError(fmt.Sprintf(
+			"Resource '%s' doesn't match delegated '%s'",
+			claimedCap.With(), delegatedCap.With(),
+		))
+	}
+
+	// Allow derivation from upload/* wildcard capability
+	if delegatedCap.Can() == UploadAbility {
+		return nil
+	}
+
+	// If not wildcard, need to validate specific constraints
+	delegatedGetCap, ok := delegated.(interface {
+		Nb() GetCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("delegated capability doesn't have GetCaveats")
+	}
+
+	if fail := equalRoot(claimedCap.Nb().Root, delegatedGetCap.Nb().Root); fail != nil {
+		return fail
+	}
+	return nil
+}
+
+// RemoveDerive implements the derivation logic for upload/remove capabilities
+func RemoveDerive(claimed, delegated any) failure.Failure {
+	// Convert to generic capabilities to access basic properties
+	claimedCap, ok := claimed.(interface {
+		Can() string
+		With() string
+		Nb() RemoveCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid claimed capability type")
+	}
+
+	delegatedCap, ok := delegated.(interface {
+		Can() string
+		With() string
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid delegated capability type")
+	}
+
+	if err := validateSpaceDID(claimedCap.With()); err != nil {
+		return err
+	}
+
+	if claimedCap.With() != delegatedCap.With() {
+		return schema.NewSchemaError(fmt.Sprintf(
+			"Resource '%s' doesn't match delegated '%s'",
+			claimedCap.With(), delegatedCap.With(),
+		))
+	}
+
+	// Allow derivation from upload/* wildcard capability
+	if delegatedCap.Can() == UploadAbility {
+		return nil
+	}
+
+	// If not wildcard, need to validate specific constraints
+	delegatedRemoveCap, ok := delegated.(interface {
+		Nb() RemoveCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("delegated capability doesn't have RemoveCaveats")
+	}
+
+	if fail := equalRoot(claimedCap.Nb().Root, delegatedRemoveCap.Nb().Root); fail != nil {
+		return fail
+	}
+
+	return nil
+}
+
+// ListDerive implements the derivation logic for upload/list capabilities
+func ListDerive(claimed, delegated any) failure.Failure {
+	// Convert to generic capabilities to access basic properties
+	claimedCap, ok := claimed.(interface {
+		Can() string
+		With() string
+		Nb() ListCaveats
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid claimed capability type")
+	}
+
+	delegatedCap, ok := delegated.(interface {
+		Can() string
+		With() string
+	})
+	if !ok {
+		return schema.NewSchemaError("invalid delegated capability type")
+	}
+
+	if err := validateSpaceDID(claimedCap.With()); err != nil {
+		return err
+	}
+
+	if claimedCap.With() != delegatedCap.With() {
+		return schema.NewSchemaError(fmt.Sprintf(
+			"Resource '%s' doesn't match delegated '%s'",
+			claimedCap.With(), delegatedCap.With(),
+		))
+	}
+
+	// Allow derivation from upload/* wildcard capability
+	if delegatedCap.Can() == UploadAbility {
+		return nil
+	}
+
+	return nil
+}

--- a/capabilities/upload/get.go
+++ b/capabilities/upload/get.go
@@ -51,6 +51,11 @@ var Get = validator.NewCapability(
 			return fail
 		}
 
+		// Allow derivation from upload/* wildcard capability
+		if delegated.Can() == UploadAbility {
+			return nil
+		}
+
 		if fail := equalRoot(claimed.Nb().Root, delegated.Nb().Root); fail != nil {
 			return fail
 		}

--- a/capabilities/upload/list.go
+++ b/capabilities/upload/list.go
@@ -69,6 +69,11 @@ var List = validator.NewCapability(
 			return fail
 		}
 
+		// Allow derivation from upload/* wildcard capability
+		if delegated.Can() == UploadAbility {
+			return nil
+		}
+
 		return nil
 	},
 )

--- a/capabilities/upload/remove.go
+++ b/capabilities/upload/remove.go
@@ -47,6 +47,11 @@ var Remove = validator.NewCapability(
 			return fail
 		}
 
+		// Allow derivation from upload/* wildcard capability
+		if delegated.Can() == UploadAbility {
+			return nil
+		}
+
 		if fail := equalRoot(claimed.Nb().Root, delegated.Nb().Root); fail != nil {
 			return fail
 		}

--- a/capabilities/upload/upload_test.go
+++ b/capabilities/upload/upload_test.go
@@ -3,7 +3,10 @@ package upload_test
 import (
 	"testing"
 
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/go-libstoracha/capabilities/upload"
+	"github.com/storacha/go-libstoracha/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,5 +15,87 @@ func TestUploadCapability(t *testing.T) {
 
 	t.Run("has correct ability", func(t *testing.T) {
 		require.Equal(t, "upload/*", capability.Can())
+	})
+}
+
+func TestUploadWildcardDerivation(t *testing.T) {
+	spaceDID := "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+	root := testutil.RandomCID(t)
+	shards := []ipld.Link{testutil.RandomCID(t), testutil.RandomCID(t)}
+
+	t.Run("upload/add can be derived from upload/*", func(t *testing.T) {
+		// Create a wildcard capability delegation
+		wildcardCap := ucan.NewCapability(upload.UploadAbility, spaceDID, struct{}{})
+		
+		// Create a specific upload/add capability
+		addCap := ucan.NewCapability(upload.AddAbility, spaceDID, upload.AddCaveats{
+			Root:   root,
+			Shards: shards,
+		})
+
+		// Test derivation using the dedicated derivation function
+		fail := upload.AddDerive(addCap, wildcardCap)
+		require.NoError(t, fail, "upload/add should be derivable from upload/*")
+	})
+
+	t.Run("upload/get can be derived from upload/*", func(t *testing.T) {
+		// Create a wildcard capability delegation
+		wildcardCap := ucan.NewCapability(upload.UploadAbility, spaceDID, struct{}{})
+		
+		// Create a specific upload/get capability
+		getCap := ucan.NewCapability(upload.GetAbility, spaceDID, upload.GetCaveats{
+			Root: root,
+		})
+
+		// Test derivation using the dedicated derivation function
+		fail := upload.GetDerive(getCap, wildcardCap)
+		require.NoError(t, fail, "upload/get should be derivable from upload/*")
+	})
+
+	t.Run("upload/remove can be derived from upload/*", func(t *testing.T) {
+		// Create a wildcard capability delegation
+		wildcardCap := ucan.NewCapability(upload.UploadAbility, spaceDID, struct{}{})
+		
+		// Create a specific upload/remove capability
+		removeCap := ucan.NewCapability(upload.RemoveAbility, spaceDID, upload.RemoveCaveats{
+			Root: root,
+		})
+
+		// Test derivation using the dedicated derivation function
+		fail := upload.RemoveDerive(removeCap, wildcardCap)
+		require.NoError(t, fail, "upload/remove should be derivable from upload/*")
+	})
+
+	t.Run("upload/list can be derived from upload/*", func(t *testing.T) {
+		// Create a wildcard capability delegation
+		wildcardCap := ucan.NewCapability(upload.UploadAbility, spaceDID, struct{}{})
+		
+		// Create a specific upload/list capability
+		listCap := ucan.NewCapability(upload.ListAbility, spaceDID, upload.ListCaveats{
+			Cursor: nil,
+			Size:   nil,
+			Pre:    nil,
+		})
+
+		// Test derivation using the dedicated derivation function
+		fail := upload.ListDerive(listCap, wildcardCap)
+		require.NoError(t, fail, "upload/list should be derivable from upload/*")
+	})
+
+	t.Run("wildcard only allows same space DID", func(t *testing.T) {
+		differentSpaceDID := "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z"
+		
+		// Create a wildcard capability delegation for one space
+		wildcardCap := ucan.NewCapability(upload.UploadAbility, spaceDID, struct{}{})
+		
+		// Create a specific upload/add capability for a different space
+		addCap := ucan.NewCapability(upload.AddAbility, differentSpaceDID, upload.AddCaveats{
+			Root:   root,
+			Shards: shards,
+		})
+
+		// Test that derivation fails when space DIDs don't match
+		fail := upload.AddDerive(addCap, wildcardCap)
+		require.Error(t, fail, "upload/add should not be derivable from upload/* with different space DID")
 	})
 }


### PR DESCRIPTION
- Add wildcard capability derivation support to all upload capabilities (add, get, remove, list)
- Allow upload/* capability to derive specific upload capabilities with same space DID
- Create standalone derivation functions for better testability and reusability
- Add comprehensive test suite covering all wildcard derivation scenarios
- Include documentation explaining wildcard capability functionality
- Maintain compatibility with existing upload capability validators
- Match functionality from JavaScript/TypeScript storacha implementation

This enables more flexible UCAN capability delegations where a single upload/* capability can authorize multiple specific upload operations.

fixes: https://github.com/storacha/go-libstoracha/issues/7

