### PR TITLE
fix: `AuthorizeCaveats`'s `iss` is a string, not a DID

### DIFF
--- a/capabilities/access/access.ipldsch
+++ b/capabilities/access/access.ipldsch
@@ -3,7 +3,7 @@ type CapabilityRequest struct {
 }
 
 type AuthorizeCaveats struct {
-  iss optional DID
+  iss optional String
   att [CapabilityRequest]
 }
 

--- a/capabilities/access/authorize.go
+++ b/capabilities/access/authorize.go
@@ -6,7 +6,6 @@ import (
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/core/schema"
-	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/go-ucanto/validator"
 )
@@ -17,7 +16,7 @@ const AuthorizeAbility = "access/authorize"
 // access/authorize invocation.
 type AuthorizeCaveats struct {
 	// DID of the Account authorization is requested from.
-	Iss *did.DID
+	Iss *string
 	// Capabilities agent wishes to be granted.
 	Att []CapabilityRequest
 }

--- a/capabilities/access/authorize_test.go
+++ b/capabilities/access/authorize_test.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/storacha/go-libstoracha/capabilities/access"
 	"github.com/storacha/go-libstoracha/internal/testutil"
-	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRoundTripAuthorizeCaveats(t *testing.T) {
-	alice := testutil.Must(did.Parse("did:mailto:example.com:alice"))(t)
+	alice := "did:mailto:example.com:alice"
 	nb := access.AuthorizeCaveats{
 		Iss: &alice,
 		Att: []access.CapabilityRequest{
@@ -43,7 +42,7 @@ func TestRoundTripAuthorizeOk(t *testing.T) {
 }
 
 func TestAuthorizeDerive(t *testing.T) {
-	alice := testutil.Must(did.Parse("did:mailto:example.com:alice"))(t)
+	alice := "did:mailto:example.com:alice"
 
 	delegated := ucan.NewCapability(
 		access.AuthorizeAbility,
@@ -80,8 +79,7 @@ func TestAuthorizeDerive(t *testing.T) {
 	})
 
 	t.Run("rejects the wrong issuer", func(t *testing.T) {
-		bob, err := did.Parse("did:mailto:example.com:bob")
-		require.NoError(t, err)
+		bob := "did:mailto:example.com:bob"
 
 		claimed := ucan.NewCapability(
 			delegated.Can(),


### PR DESCRIPTION
This was just me misreading




#### PR Dependency Tree


* **PR #35** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)