### PR TITLE
fix: `space/index/add` uses correct reader

### DIFF
--- a/capabilities/space/index/add.go
+++ b/capabilities/space/index/add.go
@@ -52,7 +52,7 @@ var AddOkReader = schema.Struct[AddOk](AddOkType(), nil, types.Converters...)
 var Add = validator.NewCapability(
 	AddAbility,
 	schema.DIDString(),
-	schema.Struct[AddCaveats](nil, nil, types.Converters...),
+	AddCaveatsReader,
 	func(claimed, delegated ucan.Capability[AddCaveats]) failure.Failure {
 		if fail := equalWith(claimed, delegated); fail != nil {
 			return fail


### PR DESCRIPTION
I tried writing a more sensible test that would actually hit this, but I don't think there's currently a good way to do that. I could force it, but it's not worth the effort—what we really need is to rework `go-ucanto`, and that's not a now project. Until then, this makes the capability work as expected.