### PR TITLE
feat: add space/content/retrieve capability

### DIFF
--- a/capabilities/space/content/content.ipldsch
+++ b/capabilities/space/content/content.ipldsch
@@ -15,6 +15,11 @@ type Range struct {
 type RetrieveOk struct {
 }
 
+type NotFoundError struct {
+    name String
+    message String
+}
+
 type RangeNotSatisfiableError struct {
     name String
     message String

--- a/capabilities/space/content/retrieve.go
+++ b/capabilities/space/content/retrieve.go
@@ -60,6 +60,24 @@ func NewRetrieveReceiptReader() (RetrieveReceiptReader, error) {
 
 var RetrieveOkReader = schema.Struct[RetrieveOk](RetrieveOkType(), nil, types.Converters...)
 
+type NotFoundError struct {
+	Name    string
+	Message string
+}
+
+func NewNotFoundError(msg string) NotFoundError {
+	return NotFoundError{
+		Name:    "NotFound",
+		Message: msg,
+	}
+}
+
+func (nfe NotFoundError) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&nfe, NotFoundErrorType(), types.Converters...)
+}
+
+var NotFoundErrorReader = schema.Struct[NotFoundError](NotFoundErrorType(), nil, types.Converters...)
+
 type RangeNotSatisfiableError struct {
 	Name    string
 	Message string
@@ -72,8 +90,8 @@ func NewRangeNotSatisfiableError(msg string) RangeNotSatisfiableError {
 	}
 }
 
-func (t RangeNotSatisfiableError) ToIPLD() (datamodel.Node, error) {
-	return ipld.WrapWithRecovery(&t, RangeNotSatisfiableErrorType(), types.Converters...)
+func (rnse RangeNotSatisfiableError) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&rnse, RangeNotSatisfiableErrorType(), types.Converters...)
 }
 
 var RangeNotSatisfiableErrorReader = schema.Struct[RangeNotSatisfiableError](RangeNotSatisfiableErrorType(), nil, types.Converters...)

--- a/capabilities/space/content/retrieve_test.go
+++ b/capabilities/space/content/retrieve_test.go
@@ -40,7 +40,18 @@ func TestRoundTripRetrieveOk(t *testing.T) {
 	require.Equal(t, ok, rok)
 }
 
-func TestRoundRangeNotSatisfiableError(t *testing.T) {
+func TestRoundTripNotFoundError(t *testing.T) {
+	expectError := content.NewNotFoundError("blob not found error")
+
+	node, err := expectError.ToIPLD()
+	require.NoError(t, err)
+
+	actualError, err := content.NotFoundErrorReader.Read(node)
+	require.NoError(t, err)
+	require.Equal(t, expectError, actualError)
+}
+
+func TestRoundTripRangeNotSatisfiableError(t *testing.T) {
 	expectError := content.NewRangeNotSatisfiableError("some range not satisfiable error")
 
 	node, err := expectError.ToIPLD()

--- a/capabilities/space/content/schema.go
+++ b/capabilities/space/content/schema.go
@@ -30,6 +30,10 @@ func RetrieveOkType() schema.Type {
 	return contentTS.TypeByName("RetrieveOk")
 }
 
+func NotFoundErrorType() schema.Type {
+	return contentTS.TypeByName("NotFoundError")
+}
+
 func RangeNotSatisfiableErrorType() schema.Type {
 	return contentTS.TypeByName("RangeNotSatisfiableError")
 }


### PR DESCRIPTION
A first implementation of the capability, we can work from here if the spec changes before merge.

Note: I took the liberty of using just `digest` in the caveats, as per https://github.com/storacha/specs/pull/139/files#r2333601709. I'll change it if that's not the final form of the spec.