### PR TITLE
feat: add `access/grant` capability definition

### DIFF
--- a/capabilities/access/access.ipldsch
+++ b/capabilities/access/access.ipldsch
@@ -36,3 +36,17 @@ type DelegateCaveats struct {
 
 type DelegateOk struct {
 }
+
+type GrantCaveats struct {
+  att [CapabilityRequest]
+  cause optional Link
+}
+
+type GrantOk struct {
+  delegations {String:Bytes}
+}
+
+type GrantError struct {
+  name String
+  message String
+}

--- a/capabilities/access/access.ipldsch
+++ b/capabilities/access/access.ipldsch
@@ -47,6 +47,6 @@ type GrantOk struct {
 }
 
 type GrantError struct {
-  name String
+  errorName String (rename "name")
   message String
 }

--- a/capabilities/access/grant.go
+++ b/capabilities/access/grant.go
@@ -46,6 +46,10 @@ type GrantError struct {
 	Message string
 }
 
+func (ge GrantError) Error() string {
+	return ge.Message
+}
+
 func (ge GrantError) ToIPLD() (datamodel.Node, error) {
 	return ipld.WrapWithRecovery(&ge, GrantErrorType(), types.Converters...)
 }

--- a/capabilities/access/grant.go
+++ b/capabilities/access/grant.go
@@ -42,8 +42,12 @@ func (gok GrantOk) ToIPLD() (datamodel.Node, error) {
 var GrantOkReader = schema.Struct[GrantOk](GrantOkType(), nil, types.Converters...)
 
 type GrantError struct {
-	Name    string
-	Message string
+	ErrorName string
+	Message   string
+}
+
+func (ge GrantError) Name() string {
+	return ge.ErrorName
 }
 
 func (ge GrantError) Error() string {

--- a/capabilities/access/grant.go
+++ b/capabilities/access/grant.go
@@ -1,0 +1,71 @@
+package access
+
+import (
+	"fmt"
+
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result/failure"
+	"github.com/storacha/go-ucanto/core/schema"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/storacha/go-ucanto/validator"
+)
+
+const GrantAbility = "access/grant"
+
+// GrantCaveats are the caveats required to perform an access/grant invocation.
+type GrantCaveats struct {
+	// Att are the capabilities agent wishes to be granted.
+	Att []CapabilityRequest
+	// Cause is an OPTIONAL link to a UCAN that provides context for the grant
+	// request. The linked UCAN MUST be included in the invocation.
+	Cause ucan.Link
+}
+
+func (gc GrantCaveats) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&gc, GrantCaveatsType(), types.Converters...)
+}
+
+var GrantCaveatsReader = schema.Struct[GrantCaveats](GrantCaveatsType(), nil, types.Converters...)
+
+// GrantOk represents the successful response for a access/grant invocation.
+type GrantOk struct {
+	Delegations DelegationsModel
+}
+
+func (gok GrantOk) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&gok, GrantOkType(), types.Converters...)
+}
+
+var GrantOkReader = schema.Struct[GrantOk](GrantOkType(), nil, types.Converters...)
+
+type GrantError struct {
+	Name    string
+	Message string
+}
+
+func (ge GrantError) ToIPLD() (datamodel.Node, error) {
+	return ipld.WrapWithRecovery(&ge, GrantErrorType(), types.Converters...)
+}
+
+type GrantReceipt receipt.Receipt[GrantOk, GrantError]
+type GrantReceiptReader receipt.ReceiptReader[GrantOk, GrantError]
+
+func NewGrantReceiptReader() (GrantReceiptReader, error) {
+	return receipt.NewReceiptReaderFromTypes[GrantOk, GrantError](GrantOkType(), GrantErrorType())
+}
+
+// Grant is a capability that allows an agent to request capabilities from the
+// invocation executor.
+var Grant = validator.NewCapability(
+	GrantAbility,
+	schema.DIDString(),
+	GrantCaveatsReader,
+	GrantDerive,
+)
+
+func GrantDerive(claimed, delegated ucan.Capability[GrantCaveats]) failure.Failure {
+	return schema.NewSchemaError(fmt.Sprintf("%s cannot be delegated", GrantAbility))
+}

--- a/capabilities/access/grant_test.go
+++ b/capabilities/access/grant_test.go
@@ -108,6 +108,7 @@ func TestGrant(t *testing.T) {
 		require.Empty(t, o)
 		require.Equal(t, grantErr.Name, x.Name)
 		require.Equal(t, grantErr.Message, x.Message)
+		require.Equal(t, grantErr.Error(), x.Error())
 	})
 }
 

--- a/capabilities/access/grant_test.go
+++ b/capabilities/access/grant_test.go
@@ -83,7 +83,7 @@ func TestGrant(t *testing.T) {
 	t.Run("round trip with error", func(t *testing.T) {
 		grantErr := access.GrantError{
 			Name:    "Unauthorized",
-			Message: "No, no you many not.",
+			Message: "No, no you may not.",
 		}
 
 		r0, err := receipt.Issue(

--- a/capabilities/access/grant_test.go
+++ b/capabilities/access/grant_test.go
@@ -1,0 +1,130 @@
+package access_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/storacha/go-libstoracha/capabilities/access"
+	"github.com/storacha/go-libstoracha/testutil"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/message"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/receipt/ran"
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/transport/car"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrant(t *testing.T) {
+	grantCaveats := access.GrantCaveats{
+		Att:   []access.CapabilityRequest{{Can: "admin/party"}},
+		Cause: testutil.RandomCID(t),
+	}
+
+	inv, err := access.Grant.Invoke(
+		testutil.Alice,
+		testutil.Bob,
+		testutil.Alice.DID().String(),
+		grantCaveats,
+	)
+	require.NoError(t, err)
+
+	t.Run("round trip", func(t *testing.T) {
+		d0, err := delegation.Delegate(
+			testutil.Bob,
+			testutil.Alice,
+			[]ucan.Capability[ucan.NoCaveats]{
+				ucan.NewCapability(grantCaveats.Att[0].Can, testutil.Bob.DID().String(), ucan.NoCaveats{}),
+			},
+		)
+		require.NoError(t, err)
+
+		d0Bytes, err := io.ReadAll(d0.Archive())
+		require.NoError(t, err)
+
+		grantOk := access.GrantOk{
+			Delegations: access.DelegationsModel{
+				Keys:   []string{d0.Link().String()},
+				Values: map[string][]byte{d0.Link().String(): d0Bytes},
+			},
+		}
+
+		r0, err := receipt.Issue(
+			testutil.Bob,
+			result.Ok[access.GrantOk, access.GrantError](grantOk),
+			ran.FromInvocation(inv),
+		)
+		require.NoError(t, err)
+
+		// round trip the invocation and receipt in an agent message to ensure the
+		// invocation can be encoded and the receipt decoded
+		msg := roundTripAgentMessage(t, []invocation.Invocation{inv}, []receipt.AnyReceipt{r0})
+
+		rcptLink, ok := msg.Get(inv.Link())
+		require.True(t, ok)
+
+		reader, err := access.NewGrantReceiptReader()
+		require.NoError(t, err)
+
+		r1, err := reader.Read(rcptLink, msg.Blocks())
+		require.NoError(t, err)
+
+		o, x := result.Unwrap(r1.Out())
+		require.Empty(t, x)
+		require.Len(t, o.Delegations.Keys, 1)
+		require.Equal(t, d0.Link().String(), o.Delegations.Keys[0])
+
+		_, err = delegation.Extract(o.Delegations.Values[d0.Link().String()])
+		require.NoError(t, err)
+	})
+
+	t.Run("round trip with error", func(t *testing.T) {
+		grantErr := access.GrantError{
+			Name:    "Unauthorized",
+			Message: "No, no you many not.",
+		}
+
+		r0, err := receipt.Issue(
+			testutil.Bob,
+			result.Error[access.GrantOk](grantErr),
+			ran.FromInvocation(inv),
+		)
+		require.NoError(t, err)
+
+		msg := roundTripAgentMessage(t, []invocation.Invocation{inv}, []receipt.AnyReceipt{r0})
+
+		rcptLink, ok := msg.Get(inv.Link())
+		require.True(t, ok)
+
+		reader, err := access.NewGrantReceiptReader()
+		require.NoError(t, err)
+
+		r1, err := reader.Read(rcptLink, msg.Blocks())
+		require.NoError(t, err)
+
+		o, x := result.Unwrap(r1.Out())
+		require.Empty(t, o)
+		require.Equal(t, grantErr.Name, x.Name)
+		require.Equal(t, grantErr.Message, x.Message)
+	})
+}
+
+func roundTripAgentMessage(t *testing.T, invs []invocation.Invocation, rcpts []receipt.AnyReceipt) message.AgentMessage {
+	t.Helper()
+	inMsg, err := message.Build(invs, rcpts)
+	require.NoError(t, err)
+
+	outCodec := car.NewOutboundCodec()
+	req, err := outCodec.Encode(inMsg)
+	require.NoError(t, err)
+
+	inCodec, err := car.NewInboundCodec().Accept(req)
+	require.NoError(t, err)
+
+	outMsg, err := inCodec.Decoder().Decode(req)
+	require.NoError(t, err)
+
+	return outMsg
+}

--- a/capabilities/access/grant_test.go
+++ b/capabilities/access/grant_test.go
@@ -82,8 +82,8 @@ func TestGrant(t *testing.T) {
 
 	t.Run("round trip with error", func(t *testing.T) {
 		grantErr := access.GrantError{
-			Name:    "Unauthorized",
-			Message: "No, no you may not.",
+			ErrorName: "Unauthorized",
+			Message:   "No, no you may not.",
 		}
 
 		r0, err := receipt.Issue(
@@ -106,7 +106,8 @@ func TestGrant(t *testing.T) {
 
 		o, x := result.Unwrap(r1.Out())
 		require.Empty(t, o)
-		require.Equal(t, grantErr.Name, x.Name)
+		require.Equal(t, grantErr.ErrorName, x.ErrorName)
+		require.Equal(t, grantErr.Name(), x.Name())
 		require.Equal(t, grantErr.Message, x.Message)
 		require.Equal(t, grantErr.Error(), x.Error())
 	})

--- a/capabilities/access/schema.go
+++ b/capabilities/access/schema.go
@@ -53,3 +53,15 @@ func DelegateCaveatsType() schema.Type {
 func DelegateOkType() schema.Type {
 	return accessTS.TypeByName("DelegateOk")
 }
+
+func GrantCaveatsType() schema.Type {
+	return accessTS.TypeByName("GrantCaveats")
+}
+
+func GrantOkType() schema.Type {
+	return accessTS.TypeByName("GrantOk")
+}
+
+func GrantErrorType() schema.Type {
+	return accessTS.TypeByName("GrantError")
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/multiformats/go-multicodec v0.9.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.0.7
-	github.com/storacha/go-ucanto v0.5.0
+	github.com/storacha/go-ucanto v0.6.5
 	github.com/stretchr/testify v1.10.0
 	github.com/whyrusleeping/cbor-gen v0.2.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t6
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/storacha/go-ucanto v0.5.0 h1:BCYfTOjJ7DxmoGwpZn4N1XITWj1BdKIbk5Ok7kMoQ6I=
-github.com/storacha/go-ucanto v0.5.0/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
+github.com/storacha/go-ucanto v0.6.5 h1:mxy1UkJDqszAGe6SkoT0N2SG9YJ62YX7fzU1Pg9lxnA=
+github.com/storacha/go-ucanto v0.6.5/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
refs https://github.com/storacha/RFC/pull/68

Since `access/authorize` is a capability that already exists and has semantics that vary slightly from what is proposed in the RFC I have named the capability `access/grant` which is roughly similar but different enough that we won't confuse the two.