### PR TITLE
fix: downgrade announce failure message to warning

### DIFF
--- a/ipnipublisher/publisher/publisher.go
+++ b/ipnipublisher/publisher/publisher.go
@@ -220,7 +220,7 @@ func (p *IPNIPublisher) publish(ctx context.Context, adv schema.Advertisement) (
 	if p.sender != nil {
 		err = announce.Send(ctx, lnk.(cidlink.Link).Cid, p.pubHTTPAnnounceAddrs, p.sender)
 		if err != nil {
-			log.Errorw("Failed to announce advertisement", "err", err)
+			log.Warnw("Failed to announce advertisement", "err", err)
 		}
 	}
 	return lnk, nil


### PR DESCRIPTION
This is not an error - it is not returned as one. It is a warning.